### PR TITLE
content-type for gzip encoding

### DIFF
--- a/webserver.go
+++ b/webserver.go
@@ -289,9 +289,6 @@ func (h *ZipHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("encrypted", "name", fname, "flag", fi.Flags)
 		}
 		ctype := make_contenttype(fi.Comment)
-		if ctype == "" {
-			ctype = make_contentbyext(fname)
-		}
 		if ctype != "" {
 			w.Header().Set("Content-Type", ctype)
 		}

--- a/webserver.go
+++ b/webserver.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	_ "embed"
 	"io/fs"
+	"mime"
 	"os"
 	"os/signal"
+	"path"
 	"sync"
 	"syscall"
 	"time"
@@ -182,6 +184,17 @@ func conditional(r *http.Request, etag string, fi *zip.File) bool {
 	return false
 }
 
+func make_contenttype(ctype string) string {
+	if mtype, param, err := mime.ParseMediaType(ctype); err == nil {
+		return mime.FormatMediaType(mtype, param)
+	}
+	return ""
+}
+
+func make_contentbyext(fname string) string {
+	return mime.TypeByExtension(path.Ext(fname))
+}
+
 func (h *ZipHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	statuscode := http.StatusOK
 	if h.accesslog != nil {
@@ -241,10 +254,17 @@ func (h *ZipHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				slog.Warn("encrypted", "name", fname, "flag", fi.Flags)
 			}
 			// fast path
-			etag := "W/" + strconv.FormatUint(uint64(fi.CRC32), 16)
+			ctype := make_contenttype(fi.Comment)
+			if ctype == "" {
+				ctype = make_contentbyext(fname)
+			}
+			if ctype != "" {
+				w.Header().Set("Content-Type", ctype)
+			}
 			for k, v := range h.headers {
 				w.Header().Set(k, v)
 			}
+			etag := "W/" + strconv.FormatUint(uint64(fi.CRC32), 16)
 			if conditional(r, etag, fi) {
 				statuscode = http.StatusNotModified
 				w.Header().Add("Etag", etag)
@@ -268,10 +288,17 @@ func (h *ZipHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// encrypted
 			slog.Warn("encrypted", "name", fname, "flag", fi.Flags)
 		}
-		etag := "W/" + strconv.FormatUint(uint64(fi.CRC32), 16)
+		ctype := make_contenttype(fi.Comment)
+		if ctype == "" {
+			ctype = make_contentbyext(fname)
+		}
+		if ctype != "" {
+			w.Header().Set("Content-Type", ctype)
+		}
 		for k, v := range h.headers {
 			w.Header().Set(k, v)
 		}
+		etag := "W/" + strconv.FormatUint(uint64(fi.CRC32), 16)
 		if conditional(r, etag, fi) {
 			statuscode = http.StatusNotModified
 			w.Header().Add("Etag", etag)


### PR DESCRIPTION
```
# curl --compressed -I http://localhost:3000/index.html
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Length: 6783
Date: Wed, 05 Mar 2025 00:30:58 GMT
Etag: W/d2a62abc
Last-Modified: Tue, 04 Mar 2025 14:20:22 GMT

# curl -I http://localhost:3000/index.html
HTTP/1.1 200 OK
Content-Length: 21279
Content-Type: text/html; charset=utf-8
Date: Wed, 05 Mar 2025 00:31:05 GMT
Etag: W/d2a62abc
Last-Modified: Tue, 04 Mar 2025 14:20:22 GMT
```